### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/on_label_change_verify_things_are_good.yml
+++ b/.github/workflows/on_label_change_verify_things_are_good.yml
@@ -23,8 +23,8 @@ jobs:
     name: GitHub Label Presets, Sync
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@v6.0.2
+      - uses: actions/setup-node@v6.2.0
         with:
           node-version: lts
       - run: |

--- a/.github/workflows/on_monday_update_actions.yml
+++ b/.github/workflows/on_monday_update_actions.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.TOKEN_FOR_GITHUB }}

--- a/.github/workflows/on_pull_request_push_run_test_and_coverage.yml
+++ b/.github/workflows/on_pull_request_push_run_test_and_coverage.yml
@@ -6,9 +6,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
       - name: Set up JDK 17
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v5.2.0
         with:
           distribution: adopt
           java-version: 17
@@ -21,7 +21,7 @@ jobs:
       # Seen on https://stackoverflow.com/a/70405596/15619
       - name: Add coverage to PR
         id: jacoco
-        uses: madrapps/jacoco-report@v1.6.1
+        uses: madrapps/jacoco-report@v1.7.2
         with:
           paths: "**/target/site/jacoco/jacoco.xml"
           token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/on_pull_request_validate_build_actions.yml
+++ b/.github/workflows/on_pull_request_validate_build_actions.yml
@@ -4,5 +4,5 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: reviewdog/action-actionlint@v1
+      - uses: actions/checkout@v6.0.2
+      - uses: reviewdog/action-actionlint@v1.70.0

--- a/.github/workflows/on_push_on_master_deploy_build.yml
+++ b/.github/workflows/on_push_on_master_deploy_build.yml
@@ -23,9 +23,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
       - name: Set up JDK 17
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v5.2.0
         with:
           distribution: adopt
           java-version: 17
@@ -52,4 +52,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v4.0.5

--- a/.github/workflows/on_workflow_dispatch_perform_maven_release.yml
+++ b/.github/workflows/on_workflow_dispatch_perform_maven_release.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - run: echo "Will perform a maven release with public version ${{ github.event.inputs.releaseversion }}"
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
         with:
           ref: main
           fetch-depth: '0'
@@ -37,7 +37,7 @@ jobs:
           token: ${{ secrets.TOKEN_FOR_GITHUB }}
       - name: Import GPG key
         id: import_gpg
-        uses: crazy-max/ghaction-import-gpg@v6.1.0
+        uses: crazy-max/ghaction-import-gpg@v6.3.0
         with:
           gpg_private_key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
@@ -48,7 +48,7 @@ jobs:
           git config --global user.email "aadarchi-releaser-bot@users.noreply.github.com"
           git config --global user.name "🤖 Aadarchi releaser bot"
       - name: Set up JDK 17
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v5.2.0
         with:
           java-version: '17'
           distribution: 'adopt'
@@ -57,7 +57,7 @@ jobs:
           server-username: ${{ secrets.OSS_SONATYPE_USERNAME }}
           server-password: ${{ secrets.OSS_SONATYPE_PASSWORD }}
       - name: Do not forget to configure Maven Settings!
-        uses: s4u/maven-settings-action@v3.0.0
+        uses: s4u/maven-settings-action@v4.0.0
         with:
           override: true
           githubServer: true


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[madrapps/jacoco-report](https://github.com/madrapps/jacoco-report)** published a new release **[v1.7.2](https://github.com/Madrapps/jacoco-report/releases/tag/v1.7.2)** on 2025-05-05T20:03:34Z
* **[s4u/maven-settings-action](https://github.com/s4u/maven-settings-action)** published a new release **[v4.0.0](https://github.com/s4u/maven-settings-action/releases/tag/v4.0.0)** on 2025-09-01T19:16:34Z
* **[actions/setup-java](https://github.com/actions/setup-java)** published a new release **[v5.2.0](https://github.com/actions/setup-java/releases/tag/v5.2.0)** on 2026-01-22T02:57:31Z
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release **[v6.2.0](https://github.com/actions/setup-node/releases/tag/v6.2.0)** on 2026-01-15T03:07:32Z
* **[actions/deploy-pages](https://github.com/actions/deploy-pages)** published a new release **[v4.0.5](https://github.com/actions/deploy-pages/releases/tag/v4.0.5)** on 2024-03-18T15:43:13Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v6.0.2](https://github.com/actions/checkout/releases/tag/v6.0.2)** on 2026-01-09T19:53:28Z
* **[crazy-max/ghaction-import-gpg](https://github.com/crazy-max/ghaction-import-gpg)** published a new release **[v6.3.0](https://github.com/crazy-max/ghaction-import-gpg/releases/tag/v6.3.0)** on 2025-03-29T23:16:53Z
* **[reviewdog/action-actionlint](https://github.com/reviewdog/action-actionlint)** published a new release **[v1.70.0](https://github.com/reviewdog/action-actionlint/releases/tag/v1.70.0)** on 2026-01-27T02:06:28Z
