### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/on_label_change_verify_things_are_good.yml
+++ b/.github/workflows/on_label_change_verify_things_are_good.yml
@@ -23,7 +23,7 @@ jobs:
     name: GitHub Label Presets, Sync
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@v7.0.0
       - uses: actions/setup-node@v6.4.0
         with:
           node-version: lts

--- a/.github/workflows/on_monday_update_actions.yml
+++ b/.github/workflows/on_monday_update_actions.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@v7.0.0
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.TOKEN_FOR_GITHUB }}

--- a/.github/workflows/on_pull_request_push_run_test_and_coverage.yml
+++ b/.github/workflows/on_pull_request_push_run_test_and_coverage.yml
@@ -6,9 +6,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@v7.0.0
       - name: Set up JDK 17
-        uses: actions/setup-java@v5.2.0
+        uses: actions/setup-java@v5.5.0
         with:
           distribution: adopt
           java-version: 17

--- a/.github/workflows/on_pull_request_validate_build_actions.yml
+++ b/.github/workflows/on_pull_request_validate_build_actions.yml
@@ -4,5 +4,5 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@v7.0.0
       - uses: reviewdog/action-actionlint@v1.72.0

--- a/.github/workflows/on_push_on_master_deploy_build.yml
+++ b/.github/workflows/on_push_on_master_deploy_build.yml
@@ -23,9 +23,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@v7.0.0
       - name: Set up JDK 17
-        uses: actions/setup-java@v5.2.0
+        uses: actions/setup-java@v5.5.0
         with:
           distribution: adopt
           java-version: 17

--- a/.github/workflows/on_workflow_dispatch_perform_maven_release.yml
+++ b/.github/workflows/on_workflow_dispatch_perform_maven_release.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - run: echo "Will perform a maven release with public version ${{ github.event.inputs.releaseversion }}"
 
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@v7.0.0
         with:
           ref: main
           fetch-depth: '0'
@@ -48,7 +48,7 @@ jobs:
           git config --global user.email "aadarchi-releaser-bot@users.noreply.github.com"
           git config --global user.name "🤖 Aadarchi releaser bot"
       - name: Set up JDK 17
-        uses: actions/setup-java@v5.2.0
+        uses: actions/setup-java@v5.5.0
         with:
           java-version: '17'
           distribution: 'adopt'


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v7.0.0](https://github.com/actions/checkout/releases/tag/v7.0.0)** on 2026-06-18T13:53:05Z
* **[actions/setup-java](https://github.com/actions/setup-java)** published a new release **[v5.5.0](https://github.com/actions/setup-java/releases/tag/v5.5.0)** on 2026-07-07T20:32:28Z
